### PR TITLE
fix(repl): IME-committed Chinese scattered to end-of-line

### DIFF
--- a/lib/agent/burst_insert.js
+++ b/lib/agent/burst_insert.js
@@ -1,0 +1,84 @@
+/*-------------------------------------------------------------------------
+ *
+ * 版权所有 (c) 2019-2026, 易景科技保留所有权利。
+ * Copyright (c) 2019-2026, Halo Tech Co.,Ltd. All rights reserved.
+ *
+ *-------------------------------------------------------------------------
+ * Workaround for a Node readline bug that corrupts MID-LINE edits fed by
+ * multi-character input chunks.
+ *
+ * Bug (node v24.10, lib/internal/readline/emitKeypressEvents.js onData):
+ * when one data event carries MULTIPLE characters — exactly what an IME
+ * commit looks like: 继续开始R1 cursor mid-line, then 推进 arrives as ONE
+ * chunk — readline replays the characters with `iface.isCompletionEnabled
+ * = false`, re-enabling it only for the LAST character. kInsertString then
+ * takes the completion-disabled fast path `this.line += c` for every char
+ * except the last: they are APPENDED AT END OF LINE, ignoring the cursor.
+ * The last char is spliced at the (per-char advanced) cursor. Result:
+ * 推 lands at end-of-line, 进 lands at cursor+1 → 继续开始R进1推 instead of
+ * 继续开始推进R1. ASCII typed key-by-key is one char per chunk, so it was
+ * never broken — the exact 中文删改后再输入就错乱 report.
+ *
+ * Fix: track the edit state at the end of every synchronous keystroke
+ * burst; when a burst consisted ONLY of plain characters and the resulting
+ * line is not the correct at-cursor splice (checked by length, so the
+ * repair can never fire on unrelated edits), rewrite line/cursor to the
+ * splice and refresh. Bursts containing named keys (arrows, enter,
+ * paste markers, …) are left to readline/PasteHandler untouched.
+ *-------------------------------------------------------------------------*/
+
+/**
+ * Install the burst-insert repair on a readline Interface. Returns an
+ * uninstall function. Fails soft: a missing input stream or a runtime
+ * without the private _refreshLine keeps today's behavior (repair skips
+ * the redraw but still fixes the edit state).
+ */
+export function repairBurstInserts(rl) {
+  if (!rl || typeof rl.input?.on !== 'function') return () => {};
+  let last = { line: rl.line ?? '', cursor: rl.cursor ?? 0 };
+  let burst = '';     // plain chars of the current synchronous burst
+  let tainted = false; // any non-printable key seen in this burst
+  let scheduled = false;
+
+  const finish = () => {
+    scheduled = false;
+    const chars = burst;
+    const bad = tainted;
+    burst = '';
+    tainted = false;
+    if (!bad && chars.length > 0) {
+      const expected = last.line.slice(0, last.cursor) + chars + last.line.slice(last.cursor);
+      // Length equality is the safety gate: the Node bug only ever MOVES the
+      // burst chars, so a length mismatch means something else edited the
+      // line in between — leave it alone.
+      if (rl.line !== expected && rl.line.length === expected.length) {
+        rl.line = expected;
+        rl.cursor = last.cursor + chars.length;
+        try { rl._refreshLine(); } catch { /* output gone */ }
+      }
+    }
+    last = { line: rl.line ?? '', cursor: rl.cursor ?? 0 };
+  };
+
+  const onKey = (str, key) => {
+    if (!scheduled) {
+      scheduled = true;
+      process.nextTick(finish);
+    }
+    // Printable-char events: readline sets key.name to the lowercased LETTER
+    // for ASCII ('X' → name 'x') but leaves it undefined for non-ASCII, so
+    // "has a name" cannot reject chars. Named control keys (left/enter/tab/
+    // paste-start/…) all have multi-char names or fail `str >= ' '`.
+    const plain = typeof str === 'string' && str.length > 0 && str >= ' '
+      && !key?.ctrl && !key?.meta
+      && (!key?.name || key.name === 'space' || key.name.length === 1);
+    if (plain) {
+      burst += str;
+    } else {
+      tainted = true;
+    }
+  };
+
+  rl.input.on('keypress', onKey);
+  return () => { rl.input.off('keypress', onKey); };
+}

--- a/lib/agent/paste.js
+++ b/lib/agent/paste.js
@@ -112,6 +112,8 @@ export class PasteHandler {
     this.pasting = false;
     /** @type {string[]} raw keypress chars of the in-flight paste */
     this.buf = [];
+    /** @type {{line: string, cursor: number}|null} edit state at paste-start */
+    this._pasteFrom = null;
     /**
      * A multi-line paste is NOT auto-submitted (the user may have more to
      * add / review). Because Node's readline cannot hold a literal '\n' in
@@ -146,6 +148,11 @@ export class PasteHandler {
       if (key.name === 'paste-start') {
         this.pasting = true;
         this.buf = [];
+        // Snapshot the edit state the paste started from. Node's readline
+        // inserts bracket-pasted chars at END of the line regardless of the
+        // cursor (v18–v24), so paste-end needs this to put the text back
+        // where the user's cursor actually was.
+        this._pasteFrom = this.rl ? { line: this.rl.line, cursor: this.rl.cursor } : null;
       } else if (key.name === 'paste-end') {
         const raw = this.buf.join('');
         this.buf = [];
@@ -193,11 +200,31 @@ export class PasteHandler {
           // Single-line paste, no trailing newline: keep it as an editable
           // draft in readline's edit buffer (rl.line). The pasted chars were
           // already echoed there by Node's _ttyWrite default-case during the
-          // paste, so rl.line already holds the text; just put the cursor at
-          // the end and refresh. The user presses Enter to submit it through
-          // the normal 'line' flow - we never fabricate an Enter.
+          // paste, so rl.line already holds the text; refresh and place the
+          // cursor.
+          //
+          // Node's internal bracketed-paste handling APPENDS the pasted chars
+          // at end-of-line regardless of where the cursor was, and the old
+          // `cursor = line.length` on top of that pinned it there. Terminals
+          // that wrap IME commits as bracketed pastes (Windows Terminal with
+          // a CJK IME, several SSH clients) therefore landed every committed
+          // Chinese character at end-of-line whenever the user edited
+          // mid-line — the "中文删改后再输入就错乱" bug. ASCII input (IME off)
+          // is never paste-wrapped, hence was never broken.
+          //
+          // Repair: when the paste-start snapshot matches (readline appended
+          // exactly the pasted text and nothing else changed), rebuild the
+          // line with the text at the snapshot's cursor — the position the
+          // user actually pasted into. Anything unexpected falls back to the
+          // legacy end-of-line behavior.
           if (this.rl) {
-            this.rl.cursor = this.rl.line.length;
+            const from = this._pasteFrom;
+            if (from && this.rl.line === from.line + text) {
+              this.rl.line = from.line.slice(0, from.cursor) + text + from.line.slice(from.cursor);
+              this.rl.cursor = from.cursor + text.length;
+            } else {
+              this.rl.cursor = this.rl.line.length;
+            }
             try { this.rl._refreshLine(); } catch { /* output gone */ }
           }
         }
@@ -269,5 +296,6 @@ export class PasteHandler {
     this.pasting = false;
     this.buf = [];
     this.pendingDraft = null;
+    this._pasteFrom = null;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hk2",
-  "version": "1.1.123",
+  "version": "1.1.124",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hk2",
-      "version": "1.1.123",
+      "version": "1.1.124",
       "dependencies": {
         "tree-sitter": "^0.21.1",
         "tree-sitter-bash": "^0.21.0",
@@ -320,6 +320,7 @@
       "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hk2",
-  "version": "1.1.123",
+  "version": "1.1.124",
   "description": "Knowledge-base-driven coding agent with per-project KB",
   "type": "module",
   "bin": {

--- a/src/commands/interactive.js
+++ b/src/commands/interactive.js
@@ -58,6 +58,7 @@ import { dispatchSlash, allSlashCompletionLabels, slashCompletions } from '../sl
 import { dynamicContextKey, fetchDynamicItems } from '../slash/completions.js';
 import { StatusBar } from '../../lib/agent/statusbar.js';
 import { PasteHandler } from '../../lib/agent/paste.js';
+import { repairBurstInserts } from '../../lib/agent/burst_insert.js';
 import { MultiLineCollector } from '../../lib/agent/multiline.js';
 import * as style from '../../lib/agent/style.js';
 import { renderLogo } from '../../lib/agent/logo.js';
@@ -436,6 +437,10 @@ export async function interactive(opts = {}) {
   // idempotent) and cheap when the box is off.
   readline.emitKeypressEvents(session.rl.input);
   session.rl.input.on('keypress', () => { refreshInputEcho(); });
+  // IME commits arrive as multi-char data chunks; Node readline appends all
+  // but the last char at end-of-line when the cursor is mid-line (see
+  // lib/agent/burst_insert.js). Repair after every keystroke burst.
+  const unrepairBursts = repairBurstInserts(session.rl);
 
   // Keep readline from auto-closing on Ctrl+C: with no rl-level 'SIGINT'
   // listener, readline closes the interface itself — the mid-turn interrupt
@@ -510,6 +515,7 @@ export async function interactive(opts = {}) {
   await new Promise((resolve) => { session.exitResolve = resolve; });
 
   unpatchRefresh();
+  unrepairBursts();
   replHints?.dispose();
   paste.stop();
   session.statusBar?.stop();

--- a/test/repl_input_edit.test.js
+++ b/test/repl_input_edit.test.js
@@ -1,0 +1,164 @@
+/*-------------------------------------------------------------------------
+ *
+ * 版权所有 (c) 2019-2026, 易景科技保留所有权利。
+ * Copyright (c) 2019-2026, Halo Tech Co.,Ltd. All rights reserved.
+ *
+ *-------------------------------------------------------------------------
+ * Regression tests for REPL input EDITING with non-keystroke-shaped input:
+ * bracketed paste and multi-char IME commit chunks.
+ *
+ * Two root causes locked down here:
+ *
+ * 1. Node's readline inserts chars received between the 200~/201~ markers
+ * at END of the edit line regardless of the cursor, and PasteHandler's
+ * paste-end handler used to force `rl.cursor = rl.line.length` on top.
+ * Terminals that wrap IME commits as bracketed pastes (Windows Terminal
+ * with a CJK IME, several SSH clients) therefore sent every committed
+ * Chinese character to end-of-line during mid-line edits. Fixed in
+ * lib/agent/paste.js via a paste-start snapshot repair.
+ *
+ * 2. Node's emitKeypressEvents replays every character of a multi-char
+ * data chunk — exactly what an IME commit looks like: 继续开始R1 with the
+ * cursor mid-line, then 推进 arrives as ONE chunk — with
+ * isCompletionEnabled=false except for the LAST char, so all but the last
+ * are APPENDED at end-of-line: 推 to EOL, 进 spliced at cursor+1 →
+ * 继续开始R进1推 instead of 继续开始推进R1 (verified against the v24.10
+ * embedded source and the user's strace byte capture). Fixed in
+ * lib/agent/burst_insert.js via a per-burst at-cursor repair.
+ *
+ * Run:  node --test test/repl_input_edit.test.js
+ *----------------------------------------------------------------------*/
+import { test } from 'node:test';
+import assert from 'node:assert';
+import readline from 'node:readline';
+import { PassThrough } from 'node:stream';
+import { PasteHandler } from '../lib/agent/paste.js';
+import { repairBurstInserts } from '../lib/agent/burst_insert.js';
+
+/**
+ * A real readline.Interface over PassThrough streams with the SAME listener
+ * wiring as interactive.js: createInterface first (readline's internal
+ * keypress listener), then PasteHandler.start(), then repairBurstInserts().
+ */
+function rig() {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  input.isTTY = true;
+  output.isTTY = true;
+  const rl = readline.createInterface({ input, output, prompt: '> ', terminal: true });
+  const handler = new PasteHandler(output, input, rl);
+  handler.start();
+  const unrepair = repairBurstInserts(rl);
+  output.read(); // drain echoes
+  return { rl, handler, input, output, unrepair };
+}
+
+/** Let the burst repair's process.nextTick run before asserting. */
+const tick = () => new Promise((r) => setImmediate(r));
+
+const wrap = (t) => `\x1b[200~${t}\x1b[201~`;
+
+test('IME-style paste-wrapped commits edit MID-LINE correctly (the 中文错乱 bug)', () => {
+  const { rl, input } = rig();
+  // Type 你好世界 via single-char bracketed commits (one per IME commit),
+  // move the cursor back two chars, backspace 好 away, type the correction.
+  for (const c of '你好世界') input.write(wrap(c));
+  input.write('\x1b[D');   // left
+  input.write('\x1b[D');   // left  → cursor between 好 and 世
+  input.write('\x7f');     // backspace deletes 好
+  assert.equal(rl.line, '你世界');
+  assert.equal(rl.cursor, 1);
+  input.write(wrap('时'));
+  input.write(wrap('间'));
+  assert.equal(rl.line, '你时间世界', 'correction lands at the cursor, not at EOL');
+  assert.equal(rl.cursor, 3, 'cursor sits right after the corrected text');
+});
+
+test('plain single-line paste at a MID-LINE cursor inserts at the cursor', () => {
+  const { rl, input } = rig();
+  input.write('abcdef');
+  input.write('\x1b[D\x1b[D\x1b[D'); // cursor=3
+  input.write(wrap('XY'));
+  assert.equal(rl.line, 'abcXYdef');
+  assert.equal(rl.cursor, 5);
+});
+
+test('paste at END of line still appends (unchanged behavior)', () => {
+  const { rl, input } = rig();
+  input.write('hi');
+  input.write(wrap('XY'));
+  assert.equal(rl.line, 'hiXY');
+  assert.equal(rl.cursor, 4);
+});
+
+test('multi-line paste still stashes a pendingDraft and clears the line', () => {
+  const { rl, handler, input } = rig();
+  input.write(wrap('first\nsecond\n'));
+  assert.equal(handler.pendingDraft, 'first\nsecond');
+  assert.equal(rl.line, '');
+});
+
+test('typing continues at the cursor after a mid-line paste', () => {
+  const { rl, input } = rig();
+  input.write('abcdef');
+  input.write('\x1b[D\x1b[D\x1b[D'); // cursor=3
+  input.write(wrap('XY'));
+  input.write('Z');                   // plain keypress, no paste wrapper
+  assert.equal(rl.line, 'abcXYZdef');
+  assert.equal(rl.cursor, 6);
+});
+
+/* ------------------------------------------------------------------ */
+/* Multi-char IME commit chunks (no paste markers — the strace shape)  */
+
+test('IME multi-char chunk edits MID-LINE correctly (the 继续开始R进1推 bug)', async () => {
+  const { rl, input } = rig();
+  // The user's REAL byte sequence (strace-verified): each IME commit is one
+  // multi-char data chunk; arrows and ASCII are single-key chunks.
+  input.write('继续'); await tick();
+  input.write('开始'); await tick();
+  input.write('R'); input.write('1'); await tick();
+  assert.equal(rl.line, '继续开始R1');
+  input.write('\x1b[D'); input.write('\x1b[D'); await tick();
+  assert.equal(rl.cursor, 4, 'cursor sits before R1');
+  input.write('推进'); await tick();
+  assert.equal(rl.line, '继续开始推进R1', 'chunk splices at the cursor, not scattered to EOL');
+  assert.equal(rl.cursor, 6);
+});
+
+test('ASCII multi-char chunk at a MID-LINE cursor splices at the cursor', async () => {
+  const { rl, input } = rig();
+  input.write('abcdef'); await tick();
+  input.write('\x1b[D\x1b[D\x1b[D'); await tick();
+  assert.equal(rl.cursor, 3);
+  input.write('XY'); await tick();
+  assert.equal(rl.line, 'abcXYdef');
+  assert.equal(rl.cursor, 5);
+});
+
+test('multi-char chunk at END of line keeps the append fast path', async () => {
+  const { rl, input } = rig();
+  input.write('ab'); await tick();
+  input.write('cd'); await tick();
+  assert.equal(rl.line, 'abcd');
+  assert.equal(rl.cursor, 4);
+});
+
+test('plain typing continues at the cursor after a repaired chunk', async () => {
+  const { rl, input } = rig();
+  input.write('abcdef'); await tick();
+  input.write('\x1b[D\x1b[D\x1b[D'); await tick();
+  input.write('XY'); await tick();
+  input.write('Z'); await tick();
+  assert.equal(rl.line, 'abcXYZdef');
+});
+
+test('burst repair never fires when the burst contains named keys', async () => {
+  const { rl, input } = rig();
+  input.write('ab'); await tick();
+  // Arrow embedded in the same chunk as text: tainted burst → readline's own
+  // (correct) single-char handling stands; the repair must not rewrite it.
+  input.write('c\x1b[D'); await tick();
+  assert.equal([...rl.line].sort().join(''), 'abc');
+  assert.ok(rl.cursor >= 0 && rl.cursor <= rl.line.length);
+});


### PR DESCRIPTION
fix(repl): IME-committed Chinese scattered to end-of-line during mid-line edits — multi-char input chunks bypass the cursor in Node readline's burst fast path;
hk2 now repairs both burst chunks and bracketed pastes to splice at the cursor (v1.1.124)

  Root cause (pinned by strace of the live process + Node's embedded source):
  the user's terminal delivers each IME commit as ONE plain multi-character
  UTF-8 chunk (继续 / 开始 / 推进 each arrive in a single read — no bracketed
  paste markers). When emitKeypressEvents.onData replays a multi-char chunk,
  it holds isCompletionEnabled=false for every character except the LAST
  (v24.10 lib/internal/readline/emitKeypressEvents.js — an optimization for
  fast end-of-line typing), so kInsertString takes the `this.line += c`
  append fast path for all but the last char, ignoring the cursor entirely.
  With the cursor mid-line: type 继续开始R1, move before R, commit 推进 →
  推 lands at end-of-line, 进 splices at cursor+1 → 继续开始R进1推. Key-by-key
  ASCII is always a single-char chunk and never affected — exactly the
  reported "turn the IME off and English/digits edit fine" asymmetry. A
  minimal pure-readline rig (zero hk2 code) reproduces the identical
  corruption, confirming this is an upstream Node defect worked around in
  hk2.

  Fix 1 (lib/agent/burst_insert.js, new): repairBurstInserts(rl) runs after
  every synchronous keystroke burst (process.nextTick); when the burst
  consisted solely of printable characters and the resulting line differs
  from the correct at-cursor splice of the burst into the pre-burst state —
  gated by length equality, since the Node bug only ever MOVES burst chars
  and a length mismatch means some other edit intervened — it rewrites
  line/cursor to the splice and refreshes. Printable-char discrimination
  gotcha: readline sets key.name to the lowercased letter for ASCII
  ('X' → 'x') but leaves it undefined for non-ASCII, so "has a name" cannot
  reject chars; named control keys (left/enter/tab/paste-start/…) all have
  multi-char names or fail `str >= ' '`. Bursts containing any named key
  (arrows, enter, paste markers) are never repaired — readline's own and
  PasteHandler's semantics stand.

  Fix 2 (lib/agent/paste.js): for terminals that DO wrap IME commits as
  bracketed pastes (Windows Terminal with a CJK IME, several SSH clients),
  Node appends pasted chars at end-of-line regardless of cursor, and the
  old paste-end handler additionally forced `rl.cursor = rl.line.length`,
  pinning the cursor there. PasteHandler now snapshots {line,cursor} at
  paste-start; on a single-line paste-end, when rl.line === snapshot.line +
  text (readline appended exactly the pasted text), the text is re-spliced
  at the snapshot cursor. Unexpected shapes fall back to the legacy
  end-of-line behavior.

  Wiring (src/commands/interactive.js): repairBurstInserts installs and
  uninstalls at the same points as PasteHandler / refreshInputEcho. The TUI
  (--tui) needs neither burst fix: its InputBox has its own grapheme-level
  editor and inserts whole chunks at the cursor via applyKey, which was
  already correct (fuzz-verified).

  Verification: new test/repl_input_edit.test.js (10 tests over a real
  readline.Interface wired exactly like interactive.js) — the user's
  strace byte sequence (chunks 继续/开始, single R and 1, two lefts, chunk
  推进) yields 继续开始推进R1; ASCII mid-line chunk (abcdef + XY@3) →
  abcXYdef; end-of-line chunks keep the append fast path; paste-wrapped
  commits, mid-line pastes, multi-line pastes, and continued typing after a
  repair all correct; named-key bursts untouched. End-to-end in a real pty,
  the full hk2 REPL draws Node's mangled intermediate state and the repair
  rewrites it to the correct line within the same frame. Full suite: 1188
  tests — the only failure is the pre-existing load-flaky config_lock race
  (3/3 green in isolation, unrelated). The patch was applied and re-verified
  on a pristine HEAD worktree.