### PR TITLE
fix: reject truncated ast_edit directory scans

### DIFF
--- a/lib/agent/tools.js
+++ b/lib/agent/tools.js
@@ -945,7 +945,10 @@ async function toolAstEdit({ ops, paths, tag }, _guard) {
     if (stat.isFile()) {
       allFiles.push(root);
     } else if (stat.isDirectory()) {
-      const { files: walked } = await globWalk(root, '**/*', 2000);
+      const { files: walked, truncated } = await globWalk(root, '**/*', 2000);
+      if (truncated) {
+        return { error: `ast_edit file enumeration exceeded 2000 files for "${p}"; narrow paths before retrying` };
+      }
       for (const f of walked) allFiles.push(f);
     }
   }
@@ -2297,7 +2300,7 @@ export function buildTools(rt, opts = {}) {
         'Template syntax in `out`: $IDENT / $$$IDENT / $_ substitute the captures matched by `pat`.',
         'Optional `tag` (shortHash of file content from a prior read/kb_outline) rejects the proposal if any target file changed since the tag was minted.',
       ],
-      description: `Structural rewrite across one or more files. Computes proposed writes (never writes to disk itself), returns a unified-diff preview plus a proposalId, then stashes the writes for resolve. Each op is {pat, out}: pat uses ast-grep metavariables ($$$IDENT, $IDENT, $_), out uses the same syntax to substitute captures. Returns { proposed, proposalId, diffs[], summary }. If no matches, returns proposed:false with summary zeroed.`,
+      description: `Structural rewrite across one or more files. Computes proposed writes (never writes to disk itself), returns a unified-diff preview plus a proposalId, then stashes the writes for resolve. Each op is {pat, out}: pat uses ast-grep metavariables ($$IDENT, $IDENT, $_), out uses the same syntax to substitute captures. Directory walks are capped at 2000 files; hitting the cap fails without staging a partial proposal. Returns { proposed, proposalId, diffs[], summary }. If no matches, returns proposed:false with summary zeroed.`,
       parameters: {
         type: 'object',
         properties: {

--- a/lib/agent/tools.js
+++ b/lib/agent/tools.js
@@ -2300,7 +2300,7 @@ export function buildTools(rt, opts = {}) {
         'Template syntax in `out`: $IDENT / $$$IDENT / $_ substitute the captures matched by `pat`.',
         'Optional `tag` (shortHash of file content from a prior read/kb_outline) rejects the proposal if any target file changed since the tag was minted.',
       ],
-      description: `Structural rewrite across one or more files. Computes proposed writes (never writes to disk itself), returns a unified-diff preview plus a proposalId, then stashes the writes for resolve. Each op is {pat, out}: pat uses ast-grep metavariables ($$IDENT, $IDENT, $_), out uses the same syntax to substitute captures. Directory walks are capped at 2000 files; hitting the cap fails without staging a partial proposal. Returns { proposed, proposalId, diffs[], summary }. If no matches, returns proposed:false with summary zeroed.`,
+      description: `Structural rewrite across one or more files. Computes proposed writes (never writes to disk itself), returns a unified-diff preview plus a proposalId, then stashes the writes for resolve. Each op is {pat, out}: pat uses ast-grep metavariables ($$$IDENT, $IDENT, $_), out uses the same syntax to substitute captures. Directory walks are capped at 2000 files; hitting the cap fails without staging a partial proposal. Returns { proposed, proposalId, diffs[], summary }. If no matches, returns proposed:false with summary zeroed.`,
       parameters: {
         type: 'object',
         properties: {

--- a/test/ast_edit_scope.test.js
+++ b/test/ast_edit_scope.test.js
@@ -1,0 +1,73 @@
+/*-------------------------------------------------------------------------
+ *
+ * Regression coverage for ast_edit directory-scope completeness.
+ *
+ * A mutation tool must never stage a proposal from a silently truncated
+ * directory walk. When the 2000-file scan cap is exceeded, ast_edit fails
+ * closed and asks the caller to narrow the requested paths.
+ *
+ * Run: node --test test/ast_edit_scope.test.js
+ *----------------------------------------------------------------------*/
+
+import './_learn_setup.js';
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { buildTools } from '../lib/agent/tools.js';
+import { resetPermissionService } from '../lib/config/setting.js';
+
+async function makeTree() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'hk2-ast-edit-scope-'));
+}
+
+async function withWorkspace(tree, fn) {
+  const prev = process.env.HK2_PROJECT_SOURCE;
+  process.env.HK2_PROJECT_SOURCE = tree;
+  resetPermissionService();
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) delete process.env.HK2_PROJECT_SOURCE;
+    else process.env.HK2_PROJECT_SOURCE = prev;
+    resetPermissionService();
+  }
+}
+
+async function writeFiles(dir, count) {
+  const batchSize = 100;
+  for (let start = 0; start < count; start += batchSize) {
+    const end = Math.min(count, start + batchSize);
+    await Promise.all(
+      Array.from({ length: end - start }, (_, offset) => {
+        const i = start + offset;
+        return fs.writeFile(path.join(dir, `file-${String(i).padStart(4, '0')}.js`), 'noop();\n');
+      }),
+    );
+  }
+}
+
+test('ast_edit fails closed when a directory scan exceeds 2000 files', async () => {
+  const tree = await makeTree();
+  try {
+    await writeFiles(tree, 2001);
+
+    await withWorkspace(tree, async () => {
+      const astEdit = buildTools(null, {}).find(t => t.name === 'ast_edit');
+      assert.ok(astEdit, 'ast_edit tool must exist');
+
+      const result = await astEdit.execute({
+        paths: [tree],
+        ops: [{ pat: 'noop()', out: 'changed()' }],
+      });
+
+      assert.match(result.error || '', /exceeded 2000 files/);
+      assert.equal(result.proposed, undefined, 'must not stage a partial proposal');
+      assert.equal(result.proposalId, undefined, 'must not return a proposal id');
+    });
+  } finally {
+    await fs.rm(tree, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Reject ast_edit when directory enumeration exceeds 2000 files.
- Do not stage a partial proposal after a truncated scan.
- Add a regression test for a 2001-file directory.

## Tests

- node --test test/ast_edit_scope.test.js

Closes #14