### PR TITLE
fix: serialize Claude model auto-import

### DIFF
--- a/src/claude_import.js
+++ b/src/claude_import.js
@@ -56,7 +56,7 @@
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import { loadModels, saveModels } from '../lib/config/home.js';
+import { loadModels, withModels } from '../lib/config/home.js';
 
 const ENV_OFF = /^(0|no|false|off)$/i;
 const PROVIDER = 'claude';
@@ -100,8 +100,8 @@ export async function autoImportClaudeModel({ homeDir } = {}) {
     return { imported: false, reason: 'disabled' };
   }
 
-  // Read models.json ONCE (a second read below would risk a lost update
-  // against a concurrent import).
+  // Use an unlocked read only for fast no-op checks.
+  // The write path checks the latest snapshot again while holding the lock.
   const modelsData = await loadModels();
   if (modelsData.default) {
     return { imported: false, reason: 'already-configured' };
@@ -143,7 +143,7 @@ export async function autoImportClaudeModel({ homeDir } = {}) {
     if (!seen.has(id)) { seen.add(id); ids.push(id); }
   }
 
-  modelsData.providers[PROVIDER] = {
+  const provider = {
     api: 'anthropic',
     apiKey,
     baseUrl,
@@ -158,7 +158,17 @@ export async function autoImportClaudeModel({ homeDir } = {}) {
       temperature: 0.2,
     })),
   };
-  modelsData.default = `${PROVIDER}/${ids[0]}`;
-  await saveModels(modelsData);
-  return { imported: true, ref: modelsData.default, models: ids };
+  return withModels((latestModels) => {
+    if (latestModels.default) {
+      return { imported: false, reason: 'already-configured' };
+    }
+    if (latestModels.providers[PROVIDER]) {
+      return { imported: false, reason: 'provider-exists' };
+    }
+
+    const ref = `${PROVIDER}/${ids[0]}`;
+    latestModels.providers[PROVIDER] = provider;
+    latestModels.default = ref;
+    return { imported: true, ref, models: ids };
+  });
 }

--- a/test/claude_import.test.js
+++ b/test/claude_import.test.js
@@ -12,6 +12,7 @@ import assert from 'node:assert';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { spawn } from 'node:child_process';
 import { autoImportClaudeModel, claudeSettingsPath } from '../src/claude_import.js';
 import { loadModels, MODELS_PATH } from '../lib/config/home.js';
 import { HK2_HOME } from './_claude_import_setup.js';
@@ -26,6 +27,57 @@ async function reset({ modelsJson = null, claudeEnv = null } = {}) {
     await fs.mkdir(path.join(claudeHome, '.claude'), { recursive: true });
     await fs.writeFile(claudeSettingsPath(claudeHome), JSON.stringify({ env: claudeEnv }));
   }
+}
+
+function startLockedModelWriter() {
+  const script = `
+    import { withModels } from ${JSON.stringify(new URL('../lib/config/home.js', import.meta.url).href)};
+    await withModels(async (data) => {
+      data.providers.concurrent = {
+        api: 'openai',
+        apiKey: 'keep',
+        models: [{ id: 'winner', name: 'winner' }],
+      };
+      data.default = 'concurrent/winner';
+      console.log('locked');
+      await new Promise((resolve) => process.stdin.once('data', resolve));
+    });
+  `;
+  const child = spawn(process.execPath, ['--input-type=module', '-e', script], {
+    env: { ...process.env, HK2_HOME },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let output = '';
+  let readyResolve;
+  let readyReject;
+  const ready = new Promise((resolve, reject) => {
+    readyResolve = resolve;
+    readyReject = reject;
+  });
+  child.stdout.on('data', (chunk) => {
+    output += chunk;
+    if (output.includes('locked')) readyResolve();
+  });
+  child.stderr.on('data', (chunk) => { output += chunk; });
+  const done = new Promise((resolve, reject) => {
+    child.on('error', (error) => {
+      readyReject(error);
+      reject(error);
+    });
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else {
+        const error = new Error(`locked writer failed (${code}): ${output}`);
+        readyReject(error);
+        reject(error);
+      }
+    });
+  });
+  return {
+    ready,
+    done,
+    release: () => child.stdin.end('release\n'),
+  };
 }
 
 beforeEach(async () => {
@@ -118,6 +170,29 @@ test('provider-exists: a user-configured claude provider is never overwritten', 
   assert.equal(saved.providers.claude.api, 'openai');
   assert.equal(saved.providers.claude.apiKey, 'keep');
   assert.equal(saved.providers.claude.baseUrl, 'https://keep');
+});
+
+test('auto-import preserves a default configured by a concurrent writer', async () => {
+  await reset({ claudeEnv: {
+    ANTHROPIC_AUTH_TOKEN: 'new',
+    ANTHROPIC_BASE_URL: 'https://new',
+  }});
+  const writer = startLockedModelWriter();
+  await writer.ready;
+
+  const importPromise = autoImportClaudeModel({ homeDir: claudeHome });
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  writer.release();
+
+  const result = await importPromise;
+  await writer.done;
+  assert.equal(result.imported, false);
+  assert.equal(result.reason, 'already-configured');
+
+  const saved = await loadModels();
+  assert.equal(saved.default, 'concurrent/winner');
+  assert.equal(saved.providers.concurrent.apiKey, 'keep');
+  assert.equal(saved.providers.claude, undefined);
 });
 
 

--- a/test/claude_import.test.js
+++ b/test/claude_import.test.js
@@ -29,55 +29,34 @@ async function reset({ modelsJson = null, claudeEnv = null } = {}) {
   }
 }
 
-function startLockedModelWriter() {
+function runModelWriter() {
   const script = `
     import { withModels } from ${JSON.stringify(new URL('../lib/config/home.js', import.meta.url).href)};
-    await withModels(async (data) => {
+    await withModels((data) => {
       data.providers.concurrent = {
         api: 'openai',
         apiKey: 'keep',
         models: [{ id: 'winner', name: 'winner' }],
       };
       data.default = 'concurrent/winner';
-      console.log('locked');
-      await new Promise((resolve) => process.stdin.once('data', resolve));
     });
   `;
   const child = spawn(process.execPath, ['--input-type=module', '-e', script], {
     env: { ...process.env, HK2_HOME },
-    stdio: ['pipe', 'pipe', 'pipe'],
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
   let output = '';
-  let readyResolve;
-  let readyReject;
-  const ready = new Promise((resolve, reject) => {
-    readyResolve = resolve;
-    readyReject = reject;
-  });
-  child.stdout.on('data', (chunk) => {
-    output += chunk;
-    if (output.includes('locked')) readyResolve();
-  });
+  child.stdout.on('data', (chunk) => { output += chunk; });
   child.stderr.on('data', (chunk) => { output += chunk; });
-  const done = new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     child.on('error', (error) => {
-      readyReject(error);
       reject(error);
     });
     child.on('close', (code) => {
       if (code === 0) resolve();
-      else {
-        const error = new Error(`locked writer failed (${code}): ${output}`);
-        readyReject(error);
-        reject(error);
-      }
+      else reject(new Error(`model writer failed (${code}): ${output}`));
     });
   });
-  return {
-    ready,
-    done,
-    release: () => child.stdin.end('release\n'),
-  };
 }
 
 beforeEach(async () => {
@@ -172,27 +151,46 @@ test('provider-exists: a user-configured claude provider is never overwritten', 
   assert.equal(saved.providers.claude.baseUrl, 'https://keep');
 });
 
-test('auto-import preserves a default configured by a concurrent writer', async () => {
+test('auto-import rechecks a stale snapshot after a concurrent default write', async () => {
   await reset({ claudeEnv: {
     ANTHROPIC_AUTH_TOKEN: 'new',
     ANTHROPIC_BASE_URL: 'https://new',
   }});
-  const writer = startLockedModelWriter();
-  await writer.ready;
+  const originalReadFile = fs.readFile;
+  let reachedSettingsRead;
+  let resumeSettingsRead;
+  const settingsRead = new Promise((resolve) => { reachedSettingsRead = resolve; });
+  const resume = new Promise((resolve) => { resumeSettingsRead = resolve; });
+  const settingsPath = claudeSettingsPath(claudeHome);
+  fs.readFile = async (file, ...args) => {
+    const content = await originalReadFile(file, ...args);
+    if (String(file) === settingsPath) {
+      // The initial models snapshot exists before this settings read.
+      reachedSettingsRead();
+      await resume;
+    }
+    return content;
+  };
 
-  const importPromise = autoImportClaudeModel({ homeDir: claudeHome });
-  await new Promise((resolve) => setTimeout(resolve, 100));
-  writer.release();
+  try {
+    const importPromise = autoImportClaudeModel({ homeDir: claudeHome });
+    await settingsRead;
+    // Commit the competing default before the importer enters its locked write.
+    await runModelWriter();
+    resumeSettingsRead();
 
-  const result = await importPromise;
-  await writer.done;
-  assert.equal(result.imported, false);
-  assert.equal(result.reason, 'already-configured');
+    const result = await importPromise;
+    assert.equal(result.imported, false);
+    assert.equal(result.reason, 'already-configured');
 
-  const saved = await loadModels();
-  assert.equal(saved.default, 'concurrent/winner');
-  assert.equal(saved.providers.concurrent.apiKey, 'keep');
-  assert.equal(saved.providers.claude, undefined);
+    const saved = await loadModels();
+    assert.equal(saved.default, 'concurrent/winner');
+    assert.equal(saved.providers.concurrent.apiKey, 'keep');
+    assert.equal(saved.providers.claude, undefined);
+  } finally {
+    resumeSettingsRead();
+    fs.readFile = originalReadFile;
+  }
 });
 
 


### PR DESCRIPTION
## Summary

- Prepare Claude provider data before taking the models lock.
- Recheck default and provider state inside withModels.
- Preserve model changes from concurrent processes.
- Add a real child-process regression test.

## Tests

- node --test test/claude_import.test.js test/config_lock.test.js
  - 14 tests passed.
- node --test test/claude_import.test.js
  - Five repeated runs passed.
- npm test
  - 1,183 tests passed.
  - Six tests outside this diff failed.
  - Two failures come from a global commit hook.
  - One existing lock stress test failed during parallel execution.
  - Three existing IME tests failed.

Closes #11