### PR TITLE
fix(edit): accept nested edits[] replaceAll and report line numbers i…

### DIFF
--- a/lib/agent/tools.js
+++ b/lib/agent/tools.js
@@ -337,6 +337,30 @@ async function toolEdit({ path: p, old_string, new_string, oldText, newText, edi
   if (!await exists(abs)) return { error: `not found: ${p}` };
 
   // Normalize: accept either {old_string,new_string} or {edits:[{oldText,newText}]}
+  // replaceAll is TOP-LEVEL by contract, but models routinely nest it inside
+  // an edits[] entry (it reads like a per-edit flag there). Silently dropping
+  // a TRUTHY nested flag produces the "oldText not unique … pass replaceAll:true"
+  // error to a caller who DID pass it — a self-contradictory message that baits
+  // a retry loop (incident: ggufmrt.c, 4 identical rounds → agent stuck).
+  // Policy: a truthy per-entry value is accepted as the same opt-in; an
+  // all-false echo of the default is ignored (no disagreement with the
+  // strict default); genuinely conflicting values are rejected, never guessed.
+  if (Array.isArray(edits) && edits.length > 0) {
+    const nested = edits.filter((e) => e && typeof e === 'object' && e.replaceAll !== undefined);
+    if (nested.length > 0) {
+      const conflict =
+        nested.some((e) => e.replaceAll === true) && nested.some((e) => e.replaceAll !== true)
+        || nested.some((e) => e.replaceAll !== true && e.replaceAll !== false)
+        || (nested.some((e) => e.replaceAll === true) && replaceAll !== undefined && !replaceAll)
+        || (nested.every((e) => e.replaceAll === false) && (replaceAll === true || replaceAll === 'all'));
+      if (conflict) {
+        return { error: 'replaceAll must be a single top-level boolean for the whole edit call; per-entry values would disagree — move it out of edits[] entries' };
+      }
+      if (nested.some((e) => e.replaceAll === true)) replaceAll = true;
+      // else: all-false per-entry flags echo the default — ignore them and
+      // proceed with strict uniqueness.
+    }
+  }
   const editList = Array.isArray(edits) && edits.length > 0
     ? edits.map(e => ({ old: e.oldText, neu: e.newText }))
     : [{ old: oldText ?? old_string, neu: newText ?? new_string }];
@@ -357,6 +381,7 @@ async function toolEdit({ path: p, old_string, new_string, oldText, newText, edi
   const fuzzyAdaptations = [];
   for (let ei = 0; ei < editList.length; ei++) {
     const e = editList[ei];
+    const replaceAllThis = replaceAll === true || replaceAll === 'all';
     if (typeof e.old !== 'string' || typeof e.neu !== 'string') return { error: 'edit.oldText/newText must be strings' };
     // Empty anchor: would match at every position (indexOf('') is always 0,
     // never -1 — which also infinite-loops the replaceAll occurrence counter
@@ -432,7 +457,7 @@ async function toolEdit({ path: p, old_string, new_string, oldText, newText, edi
     if (!fuzzyApplied) {
     const idx2 = next.indexOf(probe, idx + 1);
     if (idx2 !== -1) {
-      if (replaceAll) {
+      if (replaceAllThis) {
         // Escape hatch: replace EVERY occurrence of a non-unique anchor when
         // the caller explicitly opts in. The default stays strict — guessing
         // which occurrence was meant is how silent wrong-place edits happen.
@@ -449,7 +474,7 @@ async function toolEdit({ path: p, old_string, new_string, oldText, newText, edi
         eolAdaptations.push({ oldText: `${e.old.slice(0, 60)}${e.old.length > 60 ? '…' : ''}`, lineEndings: 'LF→CRLF', replaceAll: true, count: count + 1 });
         continue;
       }
-      return { error: `oldText not unique (matches at ${idx}, ${idx2}) — narrow the anchor, or pass replaceAll:true to replace every occurrence` };
+      return { error: buildNotUniqueMessage(next, idx, idx2) };
     }
     // Replacement text: keep the file's line-ending convention. When the
     // anchor matched in CRLF form — or the file simply uses CRLF and the
@@ -752,6 +777,32 @@ function buildEditFailureMessage(text, oldText, failedIndex, appliedBefore, tota
   if (text.includes('\r\n')) parts.push('file uses CRLF line endings; LF-form oldText is auto-adapted, CRLF-form must match byte-exactly');
   if (total > 1) parts.push(`edit ${failedIndex + 1} of ${total} failed; ${appliedBefore} earlier edit(s) matched — nothing was written`);
   return parts.join('; ');
+}
+
+/**
+ * Byte-offset → 1-based line number (offsets beyond the text clamp to the
+ * last line). The "oldText not unique" diagnostic previously printed raw
+ * byte offsets — meaningless to a model that navigates files by LINE
+ * numbers, so it could not act on the message at all.
+ */
+function offsetToLine(text, offset) {
+  let line = 1;
+  const n = Math.min(offset, text.length);
+  for (let i = 0; i < n; i++) if (text.charCodeAt(i) === 10) line++;
+  return line;
+}
+
+/**
+ * Diagnostic for a non-unique verbatim/EOL-adapted anchor. Line numbers
+ * instead of raw byte offsets — the incident (ggufmrt.c retry loop) showed
+ * the model cannot act on "matches at 69721, 71426" because it navigates
+ * files by line numbers. Reached only when replaceAll is NOT set (a set
+ * replaceAll replaces every verbatim/EOL-adapted occurrence instead of
+ * failing), so the advice to pass it is always actionable here.
+ */
+function buildNotUniqueMessage(text, idx, idx2) {
+  const lines = [idx, idx2].map((off) => `line ${offsetToLine(text, off)}`).join(', ');
+  return `oldText not unique (matches at ${lines}) — narrow the anchor to a unique span, or pass replaceAll:true at the TOP level of the edit call (not inside an edits[] entry) to replace every occurrence`;
 }
 
 async function toolGlob({ pattern, path: cwd, limit }, guard) {
@@ -2465,6 +2516,7 @@ export function buildTools(rt, opts = {}) {
         'When changing multiple separate locations in one file, use one edit call with multiple entries in edits[] instead of multiple edit calls',
         'Multi-edit entries are applied sequentially in array order against the evolving in-memory content. Each oldText must be unique at the moment its entry is processed unless replaceAll is true; later entries may observe text produced by earlier ones.',
         'Keep edits[].oldText as small as possible while still being unique in the file. Do not pad with large unchanged regions.',
+        'replaceAll is a single TOP-LEVEL boolean for the whole call. A truthy value inside an edits[] entry is accepted as the same opt-in; all-false per-entry flags echo the default and are ignored; conflicting values are rejected. When replaceAll is set, verbatim and EOL-adapted anchors are all replaced (whitespace-fuzzy ones are NOT — narrow those to a unique site instead).',
         'Pass the `tag` from a prior read/kb_outline result to opt in to stale-anchor protection: the edit is rejected when the current file hash differs from the supplied KB-index snapshot tag.',
         'Indentation/EOL drift is tolerated automatically (whitespace-insensitive fallback anchors on the file\'s own bytes and preserves its indent style/EOL); if a match still fails, re-read near the line number in the error before retrying.',
         'Set replaceAll:true only when you deliberately want every occurrence of an exact or EOL-adapted anchor replaced; ambiguous fuzzy anchors still fail.',
@@ -2489,7 +2541,7 @@ export function buildTools(rt, opts = {}) {
           old_string: { type: 'string', description: 'Single-edit shorthand for edits[0].oldText' },
           new_string: { type: 'string', description: 'Single-edit shorthand for edits[0].newText' },
           tag: { type: 'string', description: 'Optional shortHash tag from a prior read/kb_outline. Rejects the edit when the current hash differs from the supplied snapshot.' },
-          replaceAll: { type: 'boolean', description: 'When true, replace every occurrence of a non-unique anchor instead of failing. Default false (strict uniqueness).' },
+          replaceAll: { type: 'boolean', description: 'When true, replace every occurrence of a non-unique anchor instead of failing. Default false (strict uniqueness). TOP-LEVEL: it applies to the whole edits[] batch (a truthy all-true value inside an edits[] entry is accepted as the same opt-in).' },
         },
         required: ['path'],
       },

--- a/test/edit_fuzzy_anchor.test.js
+++ b/test/edit_fuzzy_anchor.test.js
@@ -226,6 +226,121 @@ test('L2 replaceAll: explicit escape hatch replaces every occurrence', async () 
   await fs.rm(tree, { recursive: true, force: true });
 });
 
+test('L2 replaceAll nested inside an edits[] entry is honored (incident: agent stuck retry loop)', async () => {
+  // Real-world shape: the model put replaceAll INSIDE the entry next to
+  // oldText/newText. The tool only read the TOP-LEVEL flag, silently dropped
+  // the nested one, and failed a non-unique anchor with "pass replaceAll:true"
+  // — advice the caller had already followed, baiting identical retries until
+  // the loop's stuck detector aborted the run (4 rounds, ~20 min lost).
+  const tree = await makeTree();
+  const f = path.join(tree, 'nested_ra.js');
+  const block = '                             resolve_n_predict(req, ggufmodel),\n                             req->output_think,\n                             ggufmrt_max_out_bytes(),';
+  const grown = '                             resolve_n_predict(req, ggufmodel),\n                             req->output_think,\n                             ggufmodel->sampling_cache.ignore_eos,\n                             ggufmrt_max_out_bytes(),';
+  await fs.writeFile(f, `void a(void) {
+  sched(m->sched,
+${block}
+                             0);
+}
+
+void b(void) {
+  sched(m->sched,
+${block}
+                             m->n_ctx);
+}
+`);
+  await withWorkspace(tree, async () => {
+    const { edit } = getTools();
+    const r = await edit.execute({
+      path: f,
+      edits: [{ oldText: block, newText: grown, replaceAll: true }], // flag nested in the entry
+    });
+    assert.equal(r.error, undefined, `nested flag must be honored, got ${JSON.stringify(r)}`);
+    const after = await fs.readFile(f, 'utf8');
+    assert.equal(after.split('ignore_eos').length - 1, 2, 'both occurrences rewritten');
+  });
+  await fs.rm(tree, { recursive: true, force: true });
+});
+
+test('L2 replaceAll: conflicting nested/top-level values are rejected, not guessed', async () => {
+  const tree = await makeTree();
+  const f = path.join(tree, 'conflict.js');
+  await fs.writeFile(f, 'foo();\nfoo();\n');
+  await withWorkspace(tree, async () => {
+    const { edit } = getTools();
+    // entry true vs top-level false → disagreement → reject
+    const r = await edit.execute({
+      path: f,
+      replaceAll: false,
+      edits: [{ oldText: 'foo();', newText: 'bar();', replaceAll: true }],
+    });
+    assert.ok(r.error && /top-level boolean/.test(r.error), `clean rejection, got ${JSON.stringify(r)}`);
+    assert.equal(await fs.readFile(f, 'utf8'), 'foo();\nfoo();\n', 'file untouched');
+    // entry false vs top-level true → disagreement → reject
+    const r2 = await edit.execute({
+      path: f,
+      replaceAll: true,
+      edits: [{ oldText: 'foo();', newText: 'bar();', replaceAll: false }],
+    });
+    assert.ok(r2.error && /top-level boolean/.test(r2.error), `conflict rejected, got ${JSON.stringify(r2)}`);
+    assert.equal(await fs.readFile(f, 'utf8'), 'foo();\nfoo();\n', 'file untouched');
+    // mixed true/false INSIDE the batch → reject
+    const r3 = await edit.execute({
+      path: f,
+      edits: [
+        { oldText: 'foo();', newText: 'bar();', replaceAll: true },
+        { oldText: 'foo();', newText: 'baz();', replaceAll: false },
+      ],
+    });
+    assert.ok(r3.error && /top-level boolean/.test(r3.error), `mixed nested rejected, got ${JSON.stringify(r3)}`);
+    assert.equal(await fs.readFile(f, 'utf8'), 'foo();\nfoo();\n', 'file untouched');
+  });
+  await fs.rm(tree, { recursive: true, force: true });
+});
+
+test('L2 replaceAll: all-false per-entry flags echo the default and are ignored', async () => {
+  // Models often re-emit explicit default flags per entry; that is not a
+  // conflict with anything — the strict default stands and the edit applies.
+  const tree = await makeTree();
+  const f = path.join(tree, 'echo_false.js');
+  await fs.writeFile(f, 'alpha();\nbeta();\n');
+  await withWorkspace(tree, async () => {
+    const { edit } = getTools();
+    const r = await edit.execute({
+      path: f,
+      edits: [{ oldText: 'beta();', newText: 'BETA();', replaceAll: false }], // no top-level flag
+    });
+    assert.equal(r.error, undefined, `default echo must succeed, got ${JSON.stringify(r)}`);
+    assert.equal(await fs.readFile(f, 'utf8'), 'alpha();\nBETA();\n');
+    // Strict uniqueness still applies — a non-unique anchor keeps failing
+    // (the echoed false must NOT be read as a silent replaceAll opt-in).
+    const f2 = path.join(tree, 'echo_false_nu.js');
+    await fs.writeFile(f2, 'dup();\ndup();\n');
+    const r2 = await edit.execute({
+      path: f2,
+      edits: [{ oldText: 'dup();', newText: 'DUP();', replaceAll: false }],
+    });
+    assert.ok(r2.error && /not unique/.test(r2.error), `still strict, got ${JSON.stringify(r2)}`);
+    assert.equal(await fs.readFile(f2, 'utf8'), 'dup();\ndup();\n', 'file untouched');
+  });
+  await fs.rm(tree, { recursive: true, force: true });
+});
+
+test('L2 not-unique diagnostic: line numbers, not raw byte offsets', async () => {
+  const tree = await makeTree();
+  const f = path.join(tree, 'diag_lines.js');
+  await fs.writeFile(f, 'pad line here\nfoo(1);\nfoo(1);\n');
+  await withWorkspace(tree, async () => {
+    const { edit } = getTools();
+    const r = await edit.execute({ path: f, old_string: 'foo(1);', new_string: 'bar(1);' });
+    assert.ok(r.error, 'non-unique anchor without replaceAll still fails');
+    assert.match(r.error, /line \d+, line \d+/, 'reports 1-based line numbers, not byte offsets');
+    assert.doesNotMatch(r.error, /matches at \d{2,}, \d{2,}/, 'no raw byte-offset pair like "matches at 69721, 71426"');
+    assert.match(r.error, /TOP level/, 'points at the top-level flag placement');
+    assert.equal(await fs.readFile(f, 'utf8'), 'pad line here\nfoo(1);\nfoo(1);\n', 'file untouched');
+  });
+  await fs.rm(tree, { recursive: true, force: true });
+});
+
 test('single-line oldText with indent drift learns the shift', async () => {
   const tree = await makeTree();
   const f = path.join(tree, 'single.js');


### PR DESCRIPTION
…n not-unique diagnostics

The ggufmrt.c incident: a model nested replaceAll:true inside an edits[] entry next to oldText/newText. The tool only read the top-level flag, silently dropped the nested one, and failed a non-unique anchor with "pass replaceAll:true" — advice the caller had already followed, baiting identical retries until the stuck detector aborted the run.

- A truthy per-entry replaceAll is now honored as the same opt-in; an all-false echo of the default is ignored; genuinely conflicting values are rejected with an explicit error instead of guessed.
- The not-unique diagnostic now reports 1-based line numbers instead of raw byte offsets ("line 3, line 9" vs "matches at 69721, 71426").
- Four regression tests covering the incident shape, three conflict forms, the all-false echo, and line-number diagnostics.